### PR TITLE
parse schedule from xml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+    - master
+
+stages:
+    - test
+    - build
+
+jobs:
+    include:
+        - stage: test
+          script: go test ./... -test.v
+        - stage: build
+          script: go build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+this is WIP
+
+Currently, only reads a xml file (like https://manage.ubucon.org/eu2019/schedule/export/schedule.xml)
+
+`go run main.go`

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ type Day struct {
 
 // Room contains each Room's schedule (each event)
 type Room struct {
+	ID     int
 	Name   string  `xml:"name,attr"`
 	Events []Event `xml:"event"`
 }
@@ -70,7 +71,7 @@ func PrintScheduleInfo(schedule Schedule) {
 	for i, day := range schedule.Days {
 		fmt.Printf("Day %v: %v\n", i+1, day.Start)
 		for _, room := range day.Rooms {
-			fmt.Printf("= Room: %v\n", room.Name)
+			fmt.Printf("= Room %v: %v\n", room.ID, room.Name)
 			for _, event := range room.Events {
 
 				// join multiple people per event
@@ -83,6 +84,32 @@ func PrintScheduleInfo(schedule Schedule) {
 			}
 		}
 		fmt.Println("")
+	}
+}
+
+// This function parses all rooms names and associate an id to them.
+// ID starts at 1 and associates with first seen room name.
+// Then it associates that ID with the room obj inside schedule.Days.
+func fixScheduleRoomsID(schedule *Schedule) {
+	roomsSlice := make([]string, 0, 10)
+
+	// iterate over rooms on all days
+	for d, day := range schedule.Days {
+		for r, room := range day.Rooms {
+
+			// keep updating the roomsSlice if a new name comes.
+			// also updates the room.ID (starting in 1)
+		RoomsSliceLoop:
+			for i, rSlice := range roomsSlice {
+				if rSlice == room.Name {
+					schedule.Days[d].Rooms[r].ID = i + 1
+					break RoomsSliceLoop
+				}
+			}
+			// only reaches this line if the room.Name is not stored yet
+			roomsSlice = append(roomsSlice, room.Name)
+			schedule.Days[d].Rooms[r].ID = len(roomsSlice)
+		}
 	}
 }
 
@@ -106,6 +133,7 @@ func main() {
 		fmt.Printf("error: %v", err)
 		return
 	}
+	fixScheduleRoomsID(&schedule)
 
 	// Print parsed XML info
 	PrintScheduleInfo(schedule)

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type Conference struct {
 	Title   string `xml:"title"`
 	Start   string `xml:"start"`
 	End     string `xml:"end"`
-	Days    string `xml:"days"`
+	Days    int    `xml:"days"`
 }
 
 // Day contains each Day's schedule (per room)

--- a/main.go
+++ b/main.go
@@ -96,8 +96,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 
 	// Parse XML
 	schedule := Schedule{}

--- a/main.go
+++ b/main.go
@@ -95,17 +95,18 @@ func fixScheduleRoomsID(schedule *Schedule) {
 
 	// iterate over rooms on all days
 	for d, day := range schedule.Days {
+	RoomsLoop:
 		for r, room := range day.Rooms {
 
 			// keep updating the roomsSlice if a new name comes.
 			// also updates the room.ID (starting in 1)
-		RoomsSliceLoop:
 			for i, rSlice := range roomsSlice {
 				if rSlice == room.Name {
 					schedule.Days[d].Rooms[r].ID = i + 1
-					break RoomsSliceLoop
+					continue RoomsLoop // just continue to the next room
 				}
 			}
+
 			// only reaches this line if the room.Name is not stored yet
 			roomsSlice = append(roomsSlice, room.Name)
 			schedule.Days[d].Rooms[r].ID = len(roomsSlice)

--- a/main.go
+++ b/main.go
@@ -2,10 +2,111 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
 
-	"github.com/PuloV/ics-golang"
+	"encoding/xml"
 )
 
+// Schedule is a sigleton containing all schedule info (see Days)
+type Schedule struct {
+	XMLName    xml.Name   `xml:"schedule"`
+	Version    string     `xml:"version"`
+	Conference Conference `xml:"conference"`
+	Days       []Day      `xml:"day"`
+}
+
+// Conference contains conference info (meta)
+type Conference struct {
+	Acronym string `xml:"acronym"`
+	Title   string `xml:"title"`
+	Start   string `xml:"start"`
+	End     string `xml:"end"`
+	Days    string `xml:"days"`
+}
+
+// Day contains each Day's schedule (per room)
+type Day struct {
+	Date  string `xml:"date,attr"`
+	Start string `xml:"start,attr"`
+	End   string `xml:"end,attr"`
+	Rooms []Room `xml:"room"`
+}
+
+// Room contains each Room's schedule (each event)
+type Room struct {
+	Name   string  `xml:"name,attr"`
+	Events []Event `xml:"event"`
+}
+
+// Event contains each talk data (the most important data)
+type Event struct {
+	ID          int      `xml:"id,attr"`
+	GUID        string   `xml:"guid,attr"`
+	Title       string   `xml:"title"`
+	Start       string   `xml:"start"`    // Hour:Minute
+	Duration    string   `xml:"duration"` // Hour:Minute
+	URL         string   `xml:"url"`
+	Slug        string   `xml:"slug"`
+	Type        string   `xml:"type"`
+	Abstract    string   `xml:"abstract"`
+	Description string   `xml:"description"`
+	Persons     []Person `xml:"persons>person"`
+}
+
+// Person is the person entity with ID
+type Person struct {
+	ID   int    `xml:"id,attr"`
+	Name string `xml:",innerxml"`
+}
+
+// PrintScheduleInfo prints unmarshaled XML schedule
+func PrintScheduleInfo(schedule Schedule) {
+	fmt.Printf("XMLName: %#v\n", schedule.XMLName)
+	fmt.Printf("Event: %v\n", schedule.Conference.Title)
+	fmt.Printf("From %v to %v (%v days)\n\n", schedule.Conference.Start, schedule.Conference.End, schedule.Conference.Days)
+
+	for i, day := range schedule.Days {
+		fmt.Printf("Day %v: %v\n", i+1, day.Start)
+		for _, room := range day.Rooms {
+			fmt.Printf("= Room: %v\n", room.Name)
+			for _, event := range room.Events {
+
+				// join multiple people per event
+				var personsStr []string
+				for _, s := range event.Persons {
+					personsStr = append(personsStr, fmt.Sprintf("%v (%v)", s.Name, s.ID))
+				}
+
+				fmt.Printf("--- %v: %v - by %v\n", event.Start, event.Title, strings.Join(personsStr, ", "))
+			}
+		}
+		fmt.Println("")
+	}
+}
+
 func main() {
-	fmt.Println("vim-go")
+
+	// Fix: maybe not so hardcoded
+	scheduleEventURL := "https://manage.ubucon.org/eu2019/schedule/export/schedule.xml"
+
+	// Get schedule from the official URL
+	resp, err := http.Get(scheduleEventURL)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	// Parse XML
+	schedule := Schedule{}
+	err = xml.Unmarshal([]byte(body), &schedule)
+	if err != nil {
+		fmt.Printf("error: %v", err)
+		return
+	}
+
+	// Print parsed XML info
+	PrintScheduleInfo(schedule)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestFixScheduleRoomsID(t *testing.T) {
+
+	exampleXML := `
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Made with love by pretalx v0.9.0. -->
+<schedule>
+    <version>0.13</version>
+    <conference>
+        <acronym>eu2019</acronym>
+        <title>Conference Title</title>
+        <start>2019-10-10</start>
+        <end>2019-10-13</end>
+        <days>4</days>
+        <timeslot_duration>00:05</timeslot_duration>
+    </conference>
+    <day index='1' date='2019-10-10' start='2019-10-10T04:00:00' end='2019-10-11T03:59:00'>
+        <room name='Room1'></room>
+        <room name='Room2'></room>
+        <room name='Room3'></room>
+        <room name='Room3' comment='This is repeated on purpose, for testing'></room>
+        <room name='Room4'></room>
+        <room name='Room5'></room>
+		</day>
+    <day index='2' date='2019-10-11' start='2019-10-11T04:00:00' end='2019-10-12T03:59:00'>
+        <room name='Room4'></room>
+        <room name='Room5'></room>
+        <room name='Room6'></room>
+		</day>
+</schedule>
+`
+
+	// Parse XML
+	schedule := Schedule{}
+	err := xml.Unmarshal([]byte(exampleXML), &schedule)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	fixScheduleRoomsID(&schedule)
+
+	if schedule.Days[0].Rooms[0].ID != 1 {
+		t.Error("The first room.ID should be 1. Instead got:", schedule.Days[0].Rooms[0].ID)
+	}
+	if schedule.Days[0].Rooms[3].ID != 3 {
+		t.Error("The fourth room is repeated and should have ID=3. Instead got:", schedule.Days[0].Rooms[3].ID)
+	}
+	if schedule.Days[1].Rooms[0].ID != 4 {
+		t.Error("The first room.ID on the second day should be 4. Instead got:", schedule.Days[1].Rooms[0].ID)
+	}
+	if schedule.Days[0].Rooms[5].ID != 5 {
+		t.Error("The sixth room.ID (day 1) should be 5. Instead got:", schedule.Days[0].Rooms[5].ID)
+	}
+	if schedule.Days[1].Rooms[2].ID != 6 {
+		t.Error("The third room.ID (day 2) should be 6. Instead got:", schedule.Days[1].Rooms[2].ID)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,6 @@ func TestFixScheduleRoomsID(t *testing.T) {
 		</day>
     <day index='2' date='2019-10-11' start='2019-10-11T04:00:00' end='2019-10-12T03:59:00'>
         <room name='Room4'></room>
-        <room name='Room5'></room>
         <room name='Room6'></room>
 		</day>
 </schedule>
@@ -57,7 +56,7 @@ func TestFixScheduleRoomsID(t *testing.T) {
 	if schedule.Days[0].Rooms[5].ID != 5 {
 		t.Error("The sixth room.ID (day 1) should be 5. Instead got:", schedule.Days[0].Rooms[5].ID)
 	}
-	if schedule.Days[1].Rooms[2].ID != 6 {
-		t.Error("The third room.ID (day 2) should be 6. Instead got:", schedule.Days[1].Rooms[2].ID)
+	if schedule.Days[1].Rooms[1].ID != 6 {
+		t.Error("The second room.ID (day 2) should be 6. Instead got:", schedule.Days[1].Rooms[1].ID)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -60,3 +60,26 @@ func TestFixScheduleRoomsID(t *testing.T) {
 		t.Error("The second room.ID (day 2) should be 6. Instead got:", schedule.Days[1].Rooms[1].ID)
 	}
 }
+
+func TestCreateRoomInfoJSONBody(t *testing.T) {
+	room := Room{ID: 1, Name: "RoomName"}
+	event := Event{
+		Title: "EventTitle",
+		Start: "10:00",
+		Persons: []Person{
+			Person{
+				Name: "PersonName1",
+			},
+			Person{
+				Name: "PersonName2",
+			},
+		},
+	}
+
+	roomInfoJSON := createRoomInfoJSONBody(room, event)
+	expectedJSON := `{"room_id":1,"room":"RoomName","title":"EventTitle","speaker":"PersonName1, PersonName2","time":"10:00","n_title":"","n_speaker":"","n_time":""}`
+
+	if string(roomInfoJSON) != expectedJSON {
+		t.Errorf("Result was not expected\n\nGot:\n%v\nExpected:\n%v\n..........\n", string(roomInfoJSON), expectedJSON)
+	}
+}

--- a/xmlParser_test.go
+++ b/xmlParser_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/xml"
+	"strconv"
+	"testing"
+)
+
+func TestXMLParser(t *testing.T) {
+
+	exampleXML := `
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Made with love by pretalx v0.9.0. -->
+<schedule>
+    <version>0.13</version>
+    <conference>
+        <acronym>eu2019</acronym>
+        <title>Conference Title</title>
+        <start>2019-10-10</start>
+        <end>2019-10-13</end>
+        <days>4</days>
+        <timeslot_duration>00:05</timeslot_duration>
+    </conference>
+    <day index='1' date='2019-10-10' start='2019-10-10T04:00:00' end='2019-10-11T03:59:00'>
+        <room name='Great Auditorium'>
+            <event guid='ed6568d5-48ed-5b18-90fc-a3bd52c7e543' id='55'>
+                <date>2019-10-10T10:00:00+01:00</date>
+                <start>10:00</start>
+                <duration>00:45</duration>
+                <room>Great Auditorium</room>
+                <slug>eu2019-55-opening-session</slug>
+                <url>https://test.dev/talk/77YFDG</url>
+                <recording>
+                    <license></license>
+                    <optout>false</optout>
+                </recording>
+                <title>Opening session</title>
+                <subtitle></subtitle>
+                <track></track>
+                <type>Long Talk</type>
+                <language>en</language>
+                <abstract>All cons need an opening session!</abstract>
+                <description>Me and other org staff members will welcome all!</description>
+                <persons>
+                    <person id='4'>Tiago A</person>
+                    <person id='5'>Tiago B</person>
+                    <person id='6'>Tiago C</person>
+                </persons>
+                <links></links>
+            </event>
+            <event guid='d54ac76b-b13c-53a8-a418-f67502e351e7' id='63'>
+                <date>2019-10-10T10:45:00+01:00</date>
+                <start>10:45</start>
+                <duration>00:30</duration>
+                <room>Great Auditorium</room>
+                <slug>eu2019-63-happy-15th-birthday-</slug>
+                <url>https://test.dev/talk/FNKHDB</url>
+                <recording>
+                    <license></license>
+                    <optout>false</optout>
+                </recording>
+                <title>Happy 15th birthday!</title>
+                <subtitle></subtitle>
+                <track></track>
+                <type>Talk</type>
+                <language>en</language>
+                <abstract>It&apos;s an orignal idea , but he couldn&apos;t make it, so I&apos;ll be his voice!</abstract>
+                <description>I&apos;ll make a retrospective of the first 15 years of our beloved Ubuntu!</description>
+                <persons>
+                    <person id='4'>Tiago A</person>
+                </persons>
+                <links></links>
+            </event>
+        </room>
+        <room name='Another Room'>
+            <event guid='337b1e60-d596-560e-86c6-12b706269be0' id='34'>
+                <date>2019-10-10T11:30:00+01:00</date>
+                <start>11:30</start>
+                <duration>00:45</duration>
+                <room>Another Room</room>
+                <slug>eu2019-34-privacy-and-decentralisation-with-multicast</slug>
+                <url>https://test.dev/talk/BVCA3C</url>
+                <recording>
+                    <license></license>
+                    <optout>false</optout>
+                </recording>
+                <title>Privacy and Decentralisation with Multicast</title>
+                <subtitle></subtitle>
+                <track></track>
+                <type>Long Talk</type>
+                <language>en</language>
+                <abstract>This talk explains why multicast is the missing piece in the decentralisation puzzle, how multicast can help the Internet continue to scale, better protect our privacy, solve IOT problems and make polar bears happier at the same time.</abstract>
+                <description>Written in 2001, RFC 3170 states:.</description>
+                <persons>
+                    <person id='37'>BB</person>
+                </persons>
+                <links></links>
+            </event>
+            
+        </room>
+        
+    </day>
+    <day index='2' date='2019-10-11' start='2019-10-11T04:00:00' end='2019-10-12T03:59:00'>
+        <room name='Great Auditorium'>
+            <event guid='8fe2f64a-536a-5196-9fec-a773552263e4' id='19'>
+                <date>2019-10-11T10:00:00+01:00</date>
+                <start>10:00</start>
+                <duration>00:30</duration>
+                <room>Great Auditorium</room>
+                <slug>eu2019-19-introduction-to-the-new-oracle-dba-mysql-oracle-</slug>
+                <url>https://test.dev/talk/YU3RGP</url>
+                <recording>
+                    <license></license>
+                    <optout>false</optout>
+                </recording>
+                <title>Introduction to the new Oracle DBA: MySQL &amp; Oracle.</title>
+                <subtitle></subtitle>
+                <track></track>
+                <type>Talk</type>
+                <language>en</language>
+                <abstract>If you&apos;re new to MySQL but know other RDBMS&apos; come along to find out how to get rid of some fears and clarify all those doubts.</abstract>
+                <description>Coming across new technology can be daunting and a challenge sometimes. In this session we aim at underlining that the technical aspect of the MySQL RDBMS are quite similar to pre-existing knowledge of other solutions. Find out what concepts are common to both, and what&apos;s different in the worlds most popular open source database.</description>
+                <persons>
+                    <person id='25'>KK</person>
+                </persons>
+                <links></links>
+            </event>
+            
+        </room>
+        
+    </day>
+</schedule>
+
+`
+	data := []byte(exampleXML)
+
+	// You may test the direct url, but hardcoded values have changed :/
+	// scheduleEventURL := "https://manage.ubucon.org/eu2019/schedule/export/schedule.xml"
+	// // Get schedule from the official URL
+	// resp, _ := http.Get(scheduleEventURL)
+	// data, _ = ioutil.ReadAll(resp.Body)
+	// resp.Body.Close()
+
+	// Parse XML
+	schedule := Schedule{}
+	err := xml.Unmarshal([]byte(data), &schedule)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	// Check some Conference meta
+	if "Conference Title" != schedule.Conference.Title {
+		t.Errorf("Unexpected Title: %s", schedule.Conference.Title)
+	}
+	if "2019-10-10" != schedule.Conference.Start {
+		t.Errorf("Unexpected Start: %s", schedule.Conference.Start)
+	}
+	if 4 != schedule.Conference.Days {
+		t.Errorf("Unexpected Days: %s", strconv.Itoa(schedule.Conference.Days))
+	}
+
+	// Check Lengths
+	if 2 != len(schedule.Days) {
+		t.Errorf("Unexpected length of days: %v", len(schedule.Days))
+	}
+	if 2 != len(schedule.Days[0].Rooms) {
+		t.Errorf("Unexpected length of Rooms on day 0: %v", len(schedule.Days[0].Rooms))
+	}
+
+	// Check some information on day 0, room 0, event 0
+	if "Great Auditorium" != schedule.Days[0].Rooms[0].Name {
+		t.Errorf("Unexpected Room name: %s", schedule.Days[0].Rooms[0].Name)
+	}
+	if "Opening session" != schedule.Days[0].Rooms[0].Events[0].Title {
+		t.Errorf("Unexpected event Title: %s", schedule.Days[0].Rooms[0].Events[0].Title)
+	}
+	if "https://test.dev/talk/77YFDG" != schedule.Days[0].Rooms[0].Events[0].URL {
+		t.Errorf("Unexpected event URL: %s", schedule.Days[0].Rooms[0].Events[0].URL)
+	}
+	if "10:00" != schedule.Days[0].Rooms[0].Events[0].Start {
+		t.Errorf("Unexpected start time: %s", schedule.Days[0].Rooms[0].Events[0].Start)
+	}
+	if 3 != len(schedule.Days[0].Rooms[0].Events[0].Persons) {
+		t.Errorf("Unexpected length of People: %v", len(schedule.Days[0].Rooms[0].Events[0].Persons))
+	}
+	if "Tiago A" != schedule.Days[0].Rooms[0].Events[0].Persons[0].Name {
+		t.Errorf("Unexpected Person name: %s", schedule.Days[0].Rooms[0].Name)
+	}
+
+}


### PR DESCRIPTION
Instead of reading the ical, I'm reading the xml. Go has a good XML parser ;)

I've parsed all relevant information provided by the pretalx xml (it's not fully complete, but it covers everything we need)

I've opted for reading directly from the exported URL, thus it will be always updated with the official schedule. I'll make some tests to the parser soon.